### PR TITLE
Dawson/add group name to get event

### DIFF
--- a/lynk_up_server/lynk_up_server/serializers.py
+++ b/lynk_up_server/lynk_up_server/serializers.py
@@ -2,9 +2,14 @@ from rest_framework import serializers
 from .models import User, Friend, Group, Event
 
 class EventSerializer(serializers.ModelSerializer):
+  group_name = serializers.SerializerMethodField()
+
   class Meta:
     model = Event
-    fields = '__all__'
+    fields = ('group', 'group_name', 'title', 'date', 'time', 'address', 'description')
+  
+  def get_group_name(self, obj):
+    return obj.group.name
 
 class UserSerializer(serializers.ModelSerializer):
   events = serializers.SerializerMethodField()

--- a/lynk_up_server/lynk_up_server/tests/api_event_test.py
+++ b/lynk_up_server/lynk_up_server/tests/api_event_test.py
@@ -33,6 +33,7 @@ def test_can_create_event(event_creation_response):
   responses.add(responses.POST, 'http://example.com', json=event_creation_response, status=201)
   payload = {
     "group_id": 1,
+    "group_name": "test name",
     "title": "postman event create test3",
     "date": "05/14/2023",
     "time": "5:00pm",

--- a/lynk_up_server/lynk_up_server/tests/conftest.py
+++ b/lynk_up_server/lynk_up_server/tests/conftest.py
@@ -209,11 +209,12 @@ def single_event_response():
 def event_creation_response():
     response_data = {
     "group_id": 1,
-    "title": "postman event create test2",
-    "date": "05/24/2023",
-    "time": "4:00pm",
-    "address": "123343 test st.",
-    "description": "test description2"
+    "group_name": "test name",
+    "title": "postman event create test3",
+    "date": "05/14/2023",
+    "time": "5:00pm",
+    "address": "143 test st.",
+    "description": "test description3"
     }
     return response_data
 


### PR DESCRIPTION
## Type of change

    [x] New feature
    [] Bug Fix
    [] Refactor

## Description of Change
    
    Add method to event serializer to return group name within the get event endpoint.
    
## Requested feedback

    I would like feedback on if this method is not working as expected, or if this is causing 500 errors.
